### PR TITLE
修改pymysql连接语句，兼容python3.8

### DIFF
--- a/Mysql2docx/Mysql2docx.py
+++ b/Mysql2docx/Mysql2docx.py
@@ -63,7 +63,8 @@ class Mysql2docx(object):
         print("dbHost:%s,dbUser:%s,dbPassword:%s,dbName:%s,dbPort:%d" % (dbHost, dbUser, dbPassword, dbName, dbPort))
         instance=Mysql2docx()
         instance.dbName=dbName
-        db = pymysql.connect(dbHost, dbUser, dbPassword, dbName, dbPort, charset="utf8")
+        # db = pymysql.connect(dbHost, dbUser, dbPassword, dbName, dbPort, charset="utf8")
+        db = pymysql.connect(host=dbHost, user=dbUser, password=dbPassword, database=dbName, port=dbPort, charset="utf8")
         tables = instance.getTables(db);
         for table in tables:
             tableName = table.name


### PR DESCRIPTION
使用python3.8进行MySQL数据库连接的时候，发现出现以下错误”init() takes 1 positional argument but 5 were given“
可能是python3.8的函数在使用时需要指定参数名，否则会使用默认的参数模板，现使用兼容写法